### PR TITLE
Use function quote in setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Add the following to your `.emacs`
 (require 'proof-site)
 
 ;; Load company-coq when opening Coq files
-(add-hook 'coq-mode-hook 'company-coq-initialize)
+(add-hook 'coq-mode-hook #'company-coq-initialize)
 ```
 
 ## Quick start guide


### PR DESCRIPTION
In modern Emacsen, it's generally recommended to use `#'` when quoting functions.