### PR TITLE
Avoid looping forever during lemma extraction

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -389,7 +389,7 @@ about shorter names, and other matches")
 
 (defconst company-coq-lemma-introduction-forms
   '("repeat match goal with H:_ |- _ => clear H end"
-    "repeat match goal with H:_ |- _ => generalize dependent H end")
+    "repeat match goal with H:_ |- _ => generalize dependent H; try (generalize dependent H; fail 1) end")
   "Forms run after 'generalize dependent ...' to produce a lemma statement")
 
 (defconst company-coq-unification-error-header


### PR DESCRIPTION
Currently, context variables will cause lemma extraction to spin off into an infinite loop since they remain in the context after `generalize dependent` is called. This prevents that from happening.

For example:

```coq
Section A.
  Context {a : nat}.

  Lemma b : a + 1 = 1 -> a = 0.
    
    (* M-x company-coq-lemma-from-goal
       - Lemma name? test <Enter>
       - Hypothesis to keep? <Enter>
       Coq process then spins out, never to return
     *)
  Abort.
End A.
```

The `try` statement fixes this by failing when the hypothesis is still available to be `generalize dependent`-ed.