### PR TITLE
Adapt to yasnippets API change

### DIFF
--- a/company-coq-pkg.el
+++ b/company-coq-pkg.el
@@ -1,6 +1,6 @@
-(define-package "company-coq" "1.0" "A collection of extensions for Proof General's Coq mode"
+(define-package "company-coq" "1.0.1" "A collection of extensions for Proof General's Coq mode"
   '((company-math "1.1")
     (company "0.8.12")
-    (yasnippet "0.9.0.1")
+    (yasnippet "0.11.0")
     (dash "2.12.1")
     (cl-lib "0.5")))

--- a/company-coq.el
+++ b/company-coq.el
@@ -4,8 +4,8 @@
 ;; Author: Clément Pit--Claudel <clement.pitclaudel@live.com>
 ;; URL: https://github.com/cpitclaudel/company-coq
 ;; Keywords: convenience, languages
-;; Package-Requires: ((cl-lib "0.5") (dash "2.12.1") (yasnippet "0.9.0.1") (company "0.8.12") (company-math "1.1"))
-;; Version: 1.0
+;; Package-Requires: ((cl-lib "0.5") (dash "2.12.1") (yasnippet "0.11.0") (company "0.8.12") (company-math "1.1"))
+;; Version: 1.0.1
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -3227,7 +3227,7 @@ These keybindings are activated by `company-coq--keybindings-minor-mode'.")
 
 (defun company-coq-snippet-at-point ()
   "Get the snippet under the current point."
-  (car (yas--snippets-at-point)))
+  (car (yas-active-snippets)))
 
 (defun company-coq-exit-snippet-if-at-exit-point ()
   "Check if exiting the CURRENT-SNIPPET would be a good idea."


### PR DESCRIPTION
Latest yasnippet [commit](https://github.com/joaotavora/yasnippet/commit/2ca6321b47c7054a339adcf982f1e4723490404a) renamed yas--snippets-at-point to yas-active-snippets. This is a tiny fix for it.

Sorry if something's wrong, never contributed to emacs packages before.