### PR TITLE
Push the current location onto the mark ring before jumping

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -2281,8 +2281,10 @@ FQN-FUNCTIONS: see `company-coq-locate-internal'."
     (xref-push-marker-stack))
   (cond
    ((bufferp location)
+    (push-mark)
     (switch-to-buffer location))
    ((and (stringp location) (file-exists-p location))
+    (push-mark)
     (find-file location))
    (t (user-error "Not found: %S" location)))
   (company-coq-search-then-scroll-up target fallback #'company-coq--pulse-and-recenter))


### PR DESCRIPTION
That way you can use C-x C-SPC (pop-global-mark) to get back to the
previous location after jumping to a definition.

I decided to save the location only if the search for the identifier succeeded, but this can be changed, I guess.