### PR TITLE
prevent "window is dedicated" errors with simple check

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -1872,8 +1872,7 @@ Nothing is reloaded immediately; instead the relevant flags are set."
                (goals-win (company-coq-get-goals-window)))
     ;; Removing this test makes everything orders of magnitude slower on Jonathan's machine
     (unless (eq (window-buffer goals-win) goals-buf)
-      (when (window-dedicated-p goals-win)
-	(set-window-dedicated-p goals-win nil))
+      (set-window-dedicated-p goals-win nil)
       (set-window-buffer goals-win goals-buf))))
 
 (defun company-coq-coq-mode-p ()

--- a/company-coq.el
+++ b/company-coq.el
@@ -1872,6 +1872,8 @@ Nothing is reloaded immediately; instead the relevant flags are set."
                (goals-win (company-coq-get-goals-window)))
     ;; Removing this test makes everything orders of magnitude slower on Jonathan's machine
     (unless (eq (window-buffer goals-win) goals-buf)
+      (when (window-dedicated-p goals-win)
+	(set-window-dedicated-p goals-win nil))
       (set-window-buffer goals-win goals-buf))))
 
 (defun company-coq-coq-mode-p ()


### PR DESCRIPTION
Tested on OSX and Linux with Emacs 25.

`set-window-buffer ` throws an error if window is dedicated to another buffer. This does a check first to prevent it. I've noticed no different behavior.

To reproduce the old error:

1. load up a file with company-coq-mode
2. step into a proof
3. hide the *response* buffer
4. step forward until QED