### PR TITLE
Wait for >1 character for math completions

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -3069,7 +3069,9 @@ COMMAND, ARG and IGNORED: see `company-backends'."
     (_ (let ((result (apply #'company-math-symbols-unicode command arg ignored)))
          (pcase command
            (`prefix (when (and result (not (string-prefix-p "_" result)))
-                      (cons result t)))
+                      (if (> (length result) 1)
+                          (cons result t)
+                        result)))
            (_ result))))))
 
 (defun company-coq-tagged-candidates (backend prefix)


### PR DESCRIPTION
Fixes an issue where `/\` would suggest all math symbols, and hitting return would complete with `\APLboxquestion` - this makes it difficult to put a logical and at the end of a line. Now completions for symbols require at least one more character after the `\`.