### PR TITLE
Make dummy hypothesis match name compatible with SSreflect

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -3457,7 +3457,7 @@ in PROTECTED depend on."
   (let* ((tracker (mapconcat (lambda (hyp)
                                (format "let dummy := (%s) in" hyp))
                              protected " ")))
-    (format "repeat match goal with __company_coq_hyp__: _ |- _ => clear dependent __company_coq_hyp__; %s idtac end" tracker)))
+    (format "repeat match goal with company_coq_hyp__: _ |- _ => clear dependent company_coq_hyp__; %s idtac end" tracker)))
 
 (defconst company-coq-lemma-from-goal--generalization-forms
   "repeat match goal with H:_ |- _ => generalize dependent H; try (generalize dependent H; fail 1) end"


### PR DESCRIPTION
SSreflect automatically generates hypothesis names with double underscores, and if you have SSreflect loaded it's an error to use such names. This patch should fix lemma extraction for SSreflect users.