### PR TITLE
Make symbols before dots rendered by prettify-symbols mode

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -590,6 +590,7 @@ The result matches any symbol in HEADERS, followed by BODY."
                                      ("True" . ?⊤) ("False" . ?⊥)
                                      ("fun" . ?λ) ("forall" . ?∀) ("exists" . ?∃)
                                      ("nat" . ?ℕ) ("Prop" . ?ℙ) ("Real" . ?ℝ) ("bool" . ?𝔹)
+				     ("->." . (?→ (Br . Bl) ?.)) ("<-." . (?← (Br . Bl) ?.)) ("|-." . (?⊢ (Br . Bl) ?.))
 
                                      ;; Extra symbols
                                      (">->" . ?↣)


### PR DESCRIPTION
This hack makes `intros ->.` and `induction n in |-.` look better.