### PR TITLE
Strip _build/default when locating files

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -2180,12 +2180,17 @@ to a non-existent file (for an example of such a case, try
                            (file-name-nondirectory (buffer-file-name proof-script-buffer))))))
       proof-script-buffer
     (let* ((lib-name (concat lib-path mod-name))
-           (output   (company-coq-ask-prover-swallow-errors (format company-coq-locate-lib-cmd lib-name))))
-      (or (and output (save-match-data
-                        (when (and (string-match company-coq-locate-lib-output-format output)
-                                   (string-match-p company-coq-compiled-regexp (match-string-no-properties 3 output)))
-                          (concat (match-string-no-properties 2 output) ".v"))))
-          (and fallback-spec (expand-file-name (concat mod-name ".v") (cdr fallback-spec)))))))
+           (output   (company-coq-ask-prover-swallow-errors (format company-coq-locate-lib-cmd lib-name)))
+           (path     (or (and output (save-match-data
+                                       (when (and (string-match company-coq-locate-lib-output-format output)
+                                                  (string-match-p company-coq-compiled-regexp (match-string-no-properties 3 output)))
+                                         (concat (match-string-no-properties 2 output) ".v"))))
+                         (and fallback-spec (expand-file-name (concat mod-name ".v") (cdr fallback-spec)))))
+           (stripped (replace-regexp-in-string "_build/default" "" path nil 'literal)))
+           (if (file-exists-p stripped)
+               stripped
+             path
+   ))))
 
 (defun company-coq--locate-name (name functions)
   "Find location of NAME using FUNCTIONS.


### PR DESCRIPTION
This PR upstreams the heuristic to locate the right file for projects using `dune` from https://github.com/ProofGeneral/PG/issues/477#issuecomment-999655573.

I don't really understand what exactly is going on in `company-coq-library-path` and this PR is just a naive adaptation of the code linked above. Please feel free to suggest better ways to write this code. I am also not sure if one should allow customization of which parts should be stripped (e.g. allow the user to give a regex that should be removed).