### PR TITLE
Fix jump-to-definition after PG#381

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -893,7 +893,8 @@ goals and response windows."
                   (proof-shell-invisible-command question 'wait nil
                                                  'no-response-display
                                                  'no-error-display
-                                                 'no-goals-display))
+                                                 'no-goals-display
+                                                 'dont-show-when-silent))
                 (company-coq-trim (company-coq--last-output-without-eager-annotation-markers)))
             (setq company-coq-talking-to-prover nil)))
       (company-coq-dbg "Prover not available; [%s] discarded" question)


### PR DESCRIPTION
https://github.com/ProofGeneral/PG/pull/831 breaks jump to definition since it adds additional Show commands, which makes `company-coq--last-output-without-eager-annotation-markers` return the wrong output. This PR fixes this by adding the `'dont-show-when-silent` flag that prevents the `Show` commands. 