### PR TITLE
prettify: Map |==> to ⟾

### DIFF
--- a/company-coq.el
+++ b/company-coq.el
@@ -566,26 +566,27 @@ The result matches any symbol in HEADERS, followed by BODY."
 (defconst company-coq-outline-heading-end-regexp "\\.[ \t\n]"
   "Regexp used to locate the end of a heading.")
 
-(defcustom company-coq-prettify-symbols-alist '(;; Disabled
-                                     ;; ("*" . ?×)  ; Inconsistent (‘intros H *’, rewrite in *, etc.)
-                                     ;; ("~" . ?¬)  ; Too invasive
-                                     ;; ("+-" . ?±) ; Too uncommon
-                                     ;; ("++" . ?⧺) ; Not present in TeX fonts
-                                     ;; ("nat" . ?𝓝) ("Prop" . ?𝓟) ; Rather uncommon
-                                     ;; ("N" . ?ℕ) ("Z" . ?ℤ) ("Q" . ?ℚ) ; Too invasive
+(defcustom company-coq-prettify-symbols-alist
+  '(;; Disabled
+    ;; ("*" . ?×)  ; Inconsistent (‘intros H *’, rewrite in *, etc.)
+    ;; ("~" . ?¬)  ; Too invasive
+    ;; ("+-" . ?±) ; Too uncommon
+    ;; ("++" . ?⧺) ; Not present in TeX fonts
+    ;; ("nat" . ?𝓝) ("Prop" . ?𝓟) ; Rather uncommon
+    ;; ("N" . ?ℕ) ("Z" . ?ℤ) ("Q" . ?ℚ) ; Too invasive
 
-                                     ;; Core Coq symbols
-                                     ("|-" . ?⊢) ("||" . ?‖) ("/\\" . ?∧) ("\\/" . ?∨)
-                                     ("->" . ?→) ("<-" . ?←) ("<->" . ?↔) ("=>" . ?⇒)
-                                     ("<=" . ?≤) (">=" . ?≥) ("<>" . ?≠)
-                                     ("True" . ?⊤) ("False" . ?⊥)
-                                     ("fun" . ?λ) ("forall" . ?∀) ("exists" . ?∃)
-                                     ("nat" . ?ℕ) ("Prop" . ?ℙ) ("Real" . ?ℝ) ("bool" . ?𝔹)
+    ;; Core Coq symbols
+    ("|-" . ?⊢) ("||" . ?‖) ("/\\" . ?∧) ("\\/" . ?∨)
+    ("->" . ?→) ("<-" . ?←) ("<->" . ?↔) ("=>" . ?⇒)
+    ("<=" . ?≤) (">=" . ?≥) ("<>" . ?≠)
+    ("True" . ?⊤) ("False" . ?⊥)
+    ("fun" . ?λ) ("forall" . ?∀) ("exists" . ?∃)
+    ("nat" . ?ℕ) ("Prop" . ?ℙ) ("Real" . ?ℝ) ("bool" . ?𝔹)
 
-                                     ;; Extra symbols
-                                     (">->" . ?↣)
-                                     ("-->" . ?⟶) ("<--" . ?⟵) ("<-->" . ?⟷)
-                                     ("==>" . ?⟹) ("<==" . ?⟸) ("~~>" . ?⟿) ("<~~" . ?⬳))
+    ;; Extra symbols
+    (">->" . ?↣)
+    ("-->" . ?⟶) ("<--" . ?⟵) ("<-->" . ?⟷)
+    ("|==>" . ?⟾) ("==>" . ?⟹) ("<==" . ?⟸) ("~~>" . ?⟿) ("<~~" . ?⬳))
   "An alist of symbols to prettify.
 Assigned to `prettify-symbols-alist' in Emacs >= 24.4."
   :group 'company-coq


### PR DESCRIPTION
This patch adds a new symbol to the prettification list.

I also added a newline and re-indented the definition of `company-coq-prettify-symbols-alist` to avoid long-lines with whitespace on the left.
If it was done on purpose, I can remove the newline in a second version.